### PR TITLE
Correct some of the mime type issues

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -473,9 +473,10 @@ module Rack
           return
         end
       }
-      assert("No Content-Type header found") {
-        Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include? status.to_i
-      }
+      # This is a SHOULD in HTTP 1.0 and 1.1:
+      # assert("No Content-Type header found") {
+      #   Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include? status.to_i
+      # }
     end
 
     ## === The Content-Length

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -21,8 +21,7 @@ module Rack
 
     def initialize(body=[], status=200, header={})
       @status = status.to_i
-      @header = Utils::HeaderHash.new("Content-Type" => "text/html").
-                                      merge(header)
+      @header = Utils::HeaderHash.new.merge(header)
 
       @chunked = "chunked" == @header['Transfer-Encoding']
       @writer  = lambda { |x| @body << x }

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -197,4 +197,25 @@ describe Rack::File do
     res['Content-Length'].should.equal "193"
   end
 
+  should "default to a mime type of text/plain" do
+    req = Rack::MockRequest.new(Rack::Lint.new(Rack::File.new(DOCROOT)))
+    res = req.get "/cgi/test"
+    res.should.be.successful
+    res['Content-Type'].should.equal "text/plain"
+  end
+
+  should "allow the default mime type to be set" do
+    req = Rack::MockRequest.new(Rack::Lint.new(Rack::File.new(DOCROOT, nil, 'application/octet-stream')))
+    res = req.get "/cgi/test"
+    res.should.be.successful
+    res['Content-Type'].should.equal "application/octet-stream"
+  end
+
+  should "not set Content-Type if the mime type is not set" do
+    req = Rack::MockRequest.new(Rack::Lint.new(Rack::File.new(DOCROOT, nil, nil)))
+    res = req.get "/cgi/test"
+    res.should.be.successful
+    res['Content-Type'].should.equal nil
+  end
+
 end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -234,12 +234,12 @@ describe Rack::Lint do
   end
 
   should "notice content-type errors" do
-    lambda {
-      Rack::Lint.new(lambda { |env|
-                       [200, {"Content-length" => "0"}, []]
-                     }).call(env({}))
-    }.should.raise(Rack::Lint::LintError).
-      message.should.match(/No Content-Type/)
+    # lambda {
+    #   Rack::Lint.new(lambda { |env|
+    #                    [200, {"Content-length" => "0"}, []]
+    #                  }).call(env({}))
+    # }.should.raise(Rack::Lint::LintError).
+    #   message.should.match(/No Content-Type/)
 
     [100, 101, 204, 205, 304].each do |status|
       lambda {

--- a/test/spec_mime.rb
+++ b/test/spec_mime.rb
@@ -1,0 +1,25 @@
+require 'rack/mime'
+
+describe Rack::Mime do
+
+  it "should return the fallback mime-type for files with no extension" do
+    fallback = 'image/jpg'
+    Rack::Mime.mime_type(File.extname('no_ext'), fallback).should == fallback
+  end
+
+  it "should always return 'application/octet-stream' for unknown file extensions" do
+    unknown_ext = File.extname('unknown_ext.abcdefg')
+    Rack::Mime.mime_type(unknown_ext).should == 'application/octet-stream'
+  end
+
+  it "should return the mime-type for a given extension" do
+    # sanity check. it would be infeasible test every single mime-type.
+    Rack::Mime.mime_type(File.extname('image.jpg')).should == 'image/jpeg'
+  end
+
+  it "should support null fallbacks" do
+    Rack::Mime.mime_type('.nothing', nil).should == nil
+  end
+
+end
+

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -6,7 +6,7 @@ describe Rack::Response do
     response = Rack::Response.new
     status, header, body = response.finish
     status.should.equal 200
-    header.should.equal "Content-Type" => "text/html"
+    header.should.equal({})
     body.each { |part|
       part.should.equal ""
     }
@@ -14,7 +14,7 @@ describe Rack::Response do
     response = Rack::Response.new
     status, header, body = *response
     status.should.equal 200
-    header.should.equal "Content-Type" => "text/html"
+    header.should.equal({})
     body.each { |part|
       part.should.equal ""
     }
@@ -37,7 +37,7 @@ describe Rack::Response do
 
   it "can set and read headers" do
     response = Rack::Response.new
-    response["Content-Type"].should.equal "text/html"
+    response["Content-Type"].should.equal nil
     response["Content-Type"] = "text/plain"
     response["Content-Type"].should.equal "text/plain"
   end


### PR DESCRIPTION
HTTP 1.0 and 1.1 do not have MUST for Content-Type requirements, they have "should" (not SHOULD). They also have text describing how clients should handle this header being missing.
